### PR TITLE
Link optional Doom custom Touch Bar demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ kernel combination has been tested. Missing T1 functionality remains in scope.
 | --- | --- | --- |
 | Touch Bar display and touch input | 🟢 Available | Default renderer, Escape, hardware controls, and F1–F12 while Fn is held. This is the Touch Bar display, not the laptop's main GPU/display. |
 | Screen and keyboard brightness buttons | 🟢 Available | Controls the machine's available Linux backlights; this does not mean T1Bridge owns those backlight drivers. |
-| Custom Touch Bar renderers | 🟢 Available | Unprivileged programs through the [renderer interface](docs/interfaces.md#renderer-selection-v1). |
+| Custom Touch Bar renderers | 🟢 Available | Unprivileged programs through the [renderer interface](docs/interfaces.md#renderer-selection-v1). Try the optional [Doom demo](#try-a-custom-touch-bar-ui). |
 | Volume, media controls, desktop HUDs | 🟡 Optional integration | Requires a desktop provider; none is bundled in the core package. |
 | Touch ID enrollment, matching and deletion | 🟢 Available | Standard fprintd tools; up to three enrolled fingers for one Linux owner. Requires preserved Apple EFI data. |
 | sudo, Polkit and lock-screen authentication | 🟡 Requires configuration | Uses `pam_fprintd`; configure each consumer and retain password fallback. |
@@ -82,6 +82,23 @@ host-wide power management are separate from T1Bridge. **Recovery of the T1's
 own functions during host sleep/wake is in scope**; fixing unrelated GPU,
 firmware, or platform suspend problems is not. This is not a complete MacBook
 hardware-enablement bundle.
+
+## Try a custom Touch Bar UI
+
+The separate Standard Agents [touchbar-doom](https://github.com/standardagents/touchbar-doom)
+package is an optional demo for Omarchy users who want to try a nonstandard
+Touch Bar UI. It runs playable Doom with a panoramic game view, labeled HUD, weapon artwork,
+and a mute toggle through T1Bridge's unprivileged renderer interface.
+
+Follow its [installation instructions](https://github.com/standardagents/touchbar-doom#install-the-optional-package)
+to install the package and supply the Doom shareware game data. Open **Touch Bar
+Doom** from the application launcher or run `touchbar-doom launch`. Tap **QUIT**
+at the far left, or press Fn, to restore the previous renderer.
+
+It is not bundled with T1Bridge or installed by default. Installing it does not
+change the active renderer; launching it is an explicit user action. Gameplay
+captures the keyboard until Quit or Fn releases it. A working T1Bridge
+Touch Bar is required first; the demo does not install hardware drivers.
 
 ## Install official packages
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -333,6 +333,12 @@ path, command, SEP payload, biometric template, or machine identifier.
 
 ## Renderer selection v1
 
+For an installable example, see the separate Standard Agents
+[touchbar-doom demo](https://github.com/standardagents/touchbar-doom).
+It is an optional Omarchy package that exercises frame submission, touch input,
+and explicit renderer selection. Its leftmost Quit button restores the prior
+renderer. T1Bridge does not install or select the demo automatically.
+
 The package always includes an unprivileged built-in renderer. A user may
 replace it by creating an executable file or symlink at
 `${XDG_CONFIG_HOME}/t1bridge/renderer`; the target may live anywhere the user


### PR DESCRIPTION
T1Bridge documents custom renderers but lacked an installable example. Link the separate optional Omarchy Doom package from the README and renderer interface, including installation, explicit launch, keyboard capture, and Quit/Fn restoration.

The demo package and source are available at https://github.com/standardagents/touchbar-doom/releases/tag/v0.1.0. This documentation change adds no dependencies or default renderer changes.

Validation: checked links and documented command syntax; `git diff --check` passes. The separate demo passes its quality checks, package tests, and local gameplay checks.

Fixes standardagents/t1bridge#3
