### PR TITLE
README: note Omarchy's update guard blocks the install's pacman -Syu

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ Use the header package matching your kernel if it is not `linux`. This performs
 a normal system upgrade. Confirm DKMS and initramfs/UKI generation succeed
 before rebooting; do not bypass signature or dependency errors.
 
+> [!NOTE]
+> **On Omarchy**, this `pacman -Syu` is blocked by Omarchy's own update guard,
+> which exists to stop a system upgrade from bypassing `omarchy update`'s
+> snapshot, keyring, and migration steps. Run the system upgrade through
+> Omarchy first, then install these packages without repeating `-u`:
+>
+> ```bash
+> omarchy update
+> sudo pacman -S --needed linux-headers t1bridge t1bridge-dkms libfprint-t1bridge fprintd-t1bridge
+> ```
+>
+> `omarchy update` already synced the databases and upgraded existing
+> packages, so the plain `-S --needed` install right after it is not a
+> partial upgrade. Do not run `pacman -Sy` (sync without upgrade) on its own
+> to work around the guard; on Arch that risks mismatched dependency versions
+> across an unevenly upgraded system. If you really need one combined
+> command, `sudo env OMARCHY_ALLOW_DIRECT_PACMAN=1 pacman -Syu --needed ...`
+> bypasses the guard for that invocation only.
+
 | Official package | Purpose |
 | --- | --- |
 | `t1bridge` | Services, importer, Touch ID broker and default Touch Bar |


### PR DESCRIPTION
The install instructions' `sudo pacman -Syu --needed ...` is exactly the transaction shape (`-S` + `-u`) Omarchy's own `00-omarchy-update-guard.hook` blocks by design:

```
Woah partner...

This looks like a direct pacman system upgrade. Omarchy updates should normally
run through:

  omarchy update
```

Every Omarchy user following this README hits that abort on first install, since it's a pre-transaction hook that fires on the flag combination alone, regardless of whether anything is actually out of date. Not a T1Bridge bug, but the README should say so and give a working path instead of leaving readers to reverse-engineer the guard's own message (which is exactly what happened when I set this up on my own MacBookPro14,3/Omarchy machine).

## What this adds

A note right after the install command recommending:

```bash
omarchy update
sudo pacman -S --needed linux-headers t1bridge t1bridge-dkms libfprint-t1bridge fprintd-t1bridge
```

`omarchy update` already syncs the databases and upgrades everything else, so the plain `-S --needed` right after it is not a partial upgrade -- and it doesn't trip the guard, since the guard only fires on `-S` + `-u` together.

Deliberately did **not** suggest `pacman -Sy` (sync without upgrade) as a workaround, since that's the exact pattern Arch itself warns against (dependency-version mismatch risk from an unevenly-synced system), just for a different reason than the guard exists for. Also mentioned the guard's own `OMARCHY_ALLOW_DIRECT_PACMAN=1` escape hatch for anyone who wants the original one-line command as-is.

## Verified

Simulated the guard's own flag-parsing logic (`/usr/bin/omarchy-update-pacman-guard`) against both command forms on an actual Omarchy machine:

- `-S --needed ...` → `has_sync=1 has_sysupgrade=0` → not blocked
- `-Syu --needed ...` → `has_sync=1 has_sysupgrade=1` → blocked

Confirms the suggested replacement actually avoids the block this note describes.

Documentation-only change; no package rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1Jd7DzNZD1sjPHfwNfaXd
